### PR TITLE
Add email templates to kickstart template so forgot password, 2FA, an…

### DIFF
--- a/light/kickstart/emails/2fa.html.ftl
+++ b/light/kickstart/emails/2fa.html.ftl
@@ -1,0 +1,8 @@
+<p>
+    To complete your login request, enter this one-time code code on the login form when prompted.
+</p>
+<p>
+    <strong>${code}</strong>
+</p>
+
+- FusionAuth Admin

--- a/light/kickstart/emails/2fa.txt.ftl
+++ b/light/kickstart/emails/2fa.txt.ftl
@@ -1,0 +1,5 @@
+To complete your login request, enter this one-time code code on the login form when prompted.
+
+${code}
+
+- FusionAuth Admin

--- a/light/kickstart/emails/breached-password.html.ftl
+++ b/light/kickstart/emails/breached-password.html.ftl
@@ -1,0 +1,11 @@
+<p>This password was found in the list of vulnerable passwords, and is no longer secure.</p>
+
+<p>In order to secure your account, it is recommended to change your password at your earliest convenience.</p>
+
+<p>Follow this link to change your password.</p>
+
+<a href="http://localhost:9011/password/forgot?email=${user.email}&tenantId=${user.tenantId}">
+  http://localhost:9011/password/forgot?email=${user.email}&tenantId=${user.tenantId}
+</a>
+
+- FusionAuth Admin

--- a/light/kickstart/emails/breached-password.txt.ftl
+++ b/light/kickstart/emails/breached-password.txt.ftl
@@ -1,0 +1,9 @@
+This password was found in the list of vulnerable passwords, and is no longer secure.
+
+In order to secure your account, it is recommended to change your password at your earliest convenience.
+
+Follow this link to change your password.
+
+http://localhost:9011/password/forgot?email=${user.email}&tenantId=${user.tenantId}
+
+- FusionAuth Admin

--- a/light/kickstart/emails/change-password.html.ftl
+++ b/light/kickstart/emails/change-password.html.ftl
@@ -1,0 +1,10 @@
+[#setting url_escaping_charset="UTF-8"]
+To change your password click on the following link.
+<p>
+  [#-- The optional 'state' map provided on the Forgot Password API call is exposed in the template as 'state' --]
+  [#assign url = "http://localhost:9011/password/change/${changePasswordId}?tenantId=${user.tenantId}" /]
+  [#list state!{} as key, value][#if key != "tenantId" && value??][#assign url = url + "&" + key?url + "=" + value?url/][/#if][/#list]
+
+  <a href="${url}">${url}</a>
+</p>
+- FusionAuth Admin

--- a/light/kickstart/emails/change-password.txt.ftl
+++ b/light/kickstart/emails/change-password.txt.ftl
@@ -1,0 +1,10 @@
+[#setting url_escaping_charset="UTF-8"]
+To change your password click on the following link.
+
+[#-- The optional 'state' map provided on the Forgot Password API call is exposed in the template as 'state' --]
+[#assign url = "http://localhost:9011/password/change/${changePasswordId}?tenantId=${user.tenantId}" /]
+[#list state!{} as key, value][#if key != "tenantId" && value??][#assign url = url + "&" + key?url + "=" + value?url/][/#if][/#list]
+
+${url}
+
+- FusionAuth Admin

--- a/light/kickstart/emails/coppa-email-plus-notice.html.ftl
+++ b/light/kickstart/emails/coppa-email-plus-notice.html.ftl
@@ -1,0 +1,5 @@
+A while ago, you granted your child consent in our system. This email is a second notice of this consent as required by law and also to remind to that you can revoke this consent at anytime on our website or by clicking the link below:
+<p>
+  <a href="http://example.com/consent/manage">http://example.com/consent/manage</a>
+</p>
+- FusionAuth Admin

--- a/light/kickstart/emails/coppa-email-plus-notice.txt.ftl
+++ b/light/kickstart/emails/coppa-email-plus-notice.txt.ftl
@@ -1,0 +1,5 @@
+A while ago, you granted your child consent in our system. This email is a second notice of this consent as required by law and also to remind to that you can revoke this consent at anytime on our website or by clicking the link below:
+
+http://example.com/consent/manage
+
+- FusionAuth Admin

--- a/light/kickstart/emails/coppa-notice.html.ftl
+++ b/light/kickstart/emails/coppa-notice.html.ftl
@@ -1,0 +1,5 @@
+You recently granted your child consent in our system. This email is to notify you of this consent. If you did not grant this consent or wish to revoke this consent, click the link below:
+<p>
+  <a href="http://example.com/consent/manage">http://example.com/consent/manage</a>
+</p>
+- FusionAuth Admin

--- a/light/kickstart/emails/coppa-notice.txt.ftl
+++ b/light/kickstart/emails/coppa-notice.txt.ftl
@@ -1,0 +1,5 @@
+You recently granted your child consent in our system. This email is to notify you of this consent. If you did not grant this consent or wish to revoke this consent, click the link below:
+
+http://example.com/consent/manage
+
+- FusionAuth Admin

--- a/light/kickstart/emails/email-verification.html.ftl
+++ b/light/kickstart/emails/email-verification.html.ftl
@@ -1,0 +1,11 @@
+[#if user.verified]
+Pro tip, your email has already been verified, but feel free to complete the verification process to verify your verification of your email address.
+[/#if]
+
+To complete your email verification click on the following link.
+<p>
+  <a href="http://localhost:9011/email/verify/${verificationId}?tenantId=${user.tenantId}">
+    http://localhost:9011/email/verify/${verificationId}?tenantId=${user.tenantId}
+  </a>
+</p>
+- FusionAuth Admin

--- a/light/kickstart/emails/email-verification.txt.ftl
+++ b/light/kickstart/emails/email-verification.txt.ftl
@@ -1,0 +1,9 @@
+[#if user.verified]
+Pro tip, your email has already been verified, but feel free to complete the verification process to verify your verification of your email address.
+[/#if]
+
+To complete your email verification click on the following link.
+
+http://localhost:9011/email/verify/${verificationId}?tenantId=${user.tenantId}
+
+- FusionAuth Admin

--- a/light/kickstart/emails/passwordless-login.html.ftl
+++ b/light/kickstart/emails/passwordless-login.html.ftl
@@ -1,0 +1,10 @@
+[#setting url_escaping_charset="UTF-8"]
+You have requested to log into FusionAuth using this email address. If you do not recognize this request please ignore this email.
+<p>
+  [#-- The optional 'state' map provided on the Start Passwordless API call is exposed in the template as 'state' --]
+  [#assign url = "http://localhost:9011/oauth2/passwordless/${code}?tenantId=${user.tenantId}" /]
+  [#list state!{} as key, value][#if key != "tenantId" && value??][#assign url = url + "&" + key?url + "=" + value?url/][/#if][/#list]
+
+  <a href="${url}">${url}</a>
+</p>
+- FusionAuth Admin

--- a/light/kickstart/emails/passwordless-login.txt.ftl
+++ b/light/kickstart/emails/passwordless-login.txt.ftl
@@ -1,0 +1,10 @@
+[#setting url_escaping_charset="UTF-8"]
+You have requested to log into FusionAuth using this email address. If you do not recognize this request please ignore this email.
+
+[#-- The optional 'state' map provided on the Start Passwordless API call is exposed in the template as 'state' --]
+[#assign url = "http://localhost:9011/oauth2/passwordless/${code}?tenantId=${user.tenantId}" /]
+[#list state!{} as key, value][#if key != "tenantId" && value??][#assign url = url + "&" + key?url + "=" + value?url/][/#if][/#list]
+
+${url}
+
+- FusionAuth Admin

--- a/light/kickstart/emails/registration-verification.html.ftl
+++ b/light/kickstart/emails/registration-verification.html.ftl
@@ -1,0 +1,11 @@
+[#if registration.verified]
+Pro tip, your registration has already been verified, but feel free to complete the verification process to verify your verification of your registration.
+[/#if]
+
+To complete your registration verification click on the following link.
+<p>
+  <a href="http://localhost:9011/registration/verify/${verificationId}?tenantId=${user.tenantId}">
+    http://localhost:9011/registration/verify/${verificationId}?tenantId=${user.tenantId}
+  </a>
+</p>
+- FusionAuth Admin

--- a/light/kickstart/emails/registration-verification.txt.ftl
+++ b/light/kickstart/emails/registration-verification.txt.ftl
@@ -1,0 +1,9 @@
+[#if registration.verified]
+Pro tip, your registration has already been verified, but feel free to complete the verification process to verify your verification of your registration.
+[/#if]
+
+To complete your registration verification click on the following link.
+
+http://localhost:9011/registration/verify/${verificationId}?tenantId=${user.tenantId}
+
+- FusionAuth Admin

--- a/light/kickstart/emails/setup-password.html.ftl
+++ b/light/kickstart/emails/setup-password.html.ftl
@@ -1,0 +1,7 @@
+Your account has been created and you must setup a password. Click on the following link to setup your password.
+<p>
+  <a href="http://localhost:9011/password/change/${changePasswordId}?tenantId=${user.tenantId}">
+    http://localhost:9011/password/change/${changePasswordId}?tenantId=${user.tenantId}
+  </a>
+</p>
+- FusionAuth Admin

--- a/light/kickstart/emails/setup-password.txt.ftl
+++ b/light/kickstart/emails/setup-password.txt.ftl
@@ -1,0 +1,5 @@
+Your account has been created and you must setup a password. Click on the following link to setup your password.
+
+http://localhost:9011/password/change/${changePasswordId}?tenantId=${user.tenantId}
+
+- FusionAuth Admin

--- a/light/kickstart/kickstart.json
+++ b/light/kickstart/kickstart.json
@@ -104,6 +104,206 @@
           }
         }
       }
+    },
+
+
+
+
+
+
+    {
+      "method": "POST",
+      "url": "/api/email/template/0502df1e-4010-4b43-b571-d423fce978b2",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Reset your password",
+          "defaultHtmlTemplate": "@{emails/change-password.html.ftl}",
+          "defaultTextTemplate": "@{emails/change-password.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "Forgot Password"
+        }
+      }
+    },
+    {
+      "method": "PATCH",
+      "url": "/api/tenant/#{defaultTenantId}",
+      "body": {
+        "tenant": {
+          "emailConfiguration": {
+            "forgotPasswordEmailTemplateId": "0502df1e-4010-4b43-b571-d423fce978b2"
+          }
+        }
+      }
+    },
+
+    {
+      "method": "POST",
+      "url": "/api/email/template/e160cc59-a73e-4d95-8287-f82e5c541a5c",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Setup your password",
+          "defaultHtmlTemplate": "@{emails/setup-password.html.ftl}",
+          "defaultTextTemplate": "@{emails/setup-password.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "Setup Password"
+        }
+      }
+    },
+    {
+      "method": "PATCH",
+      "url": "/api/tenant/#{defaultTenantId}",
+      "body": {
+        "tenant": {
+          "emailConfiguration": {
+            "setPasswordEmailTemplateId": "e160cc59-a73e-4d95-8287-f82e5c541a5c"
+          }
+        }
+      }
+    },
+
+    {
+      "method": "POST",
+      "url": "/api/email/template/7fa81426-42a9-4eb2-ac09-73c044d410b1",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Verify your FusionAuth email address",
+          "defaultHtmlTemplate": "@{emails/email-verification.html.ftl}",
+          "defaultTextTemplate": "@{emails/email-verification.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "Email Verification"
+        }
+      }
+    },
+    {
+      "method": "PATCH",
+      "url": "/api/tenant/#{defaultTenantId}",
+      "body": {
+        "tenant": {
+          "emailConfiguration": {
+            "verificationEmailTemplateId": "7fa81426-42a9-4eb2-ac09-73c044d410b1"
+          }
+        }
+      }
+    },
+
+    {
+      "method": "POST",
+      "url": "/api/email/template/c16b65a5-e6e9-4499-a7ac-ae228f8d9864",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Verify your Registration",
+          "defaultHtmlTemplate": "@{emails/registration-verification.html.ftl}",
+          "defaultTextTemplate": "@{emails/registration-verification.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "Registration Verification"
+        }
+      }
+    },
+
+    {
+      "method": "POST",
+      "url": "/api/email/template/fa6668cb-8569-44df-b0a2-8fcd996df915",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Log into FusionAuth",
+          "defaultHtmlTemplate": "@{emails/passwordless-login.html.ftl}",
+          "defaultTextTemplate": "@{emails/passwordless-login.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "Passwordless Login"
+        }
+      }
+    },
+    {
+      "method": "PATCH",
+      "url": "/api/tenant/#{defaultTenantId}",
+      "body": {
+        "tenant": {
+          "emailConfiguration": {
+            "passwordlessEmailTemplateId": "fa6668cb-8569-44df-b0a2-8fcd996df915"
+          }
+        }
+      }
+    },
+
+    {
+      "method": "POST",
+      "url": "/api/email/template/162b3719-3d71-4638-b9bf-f3e2093f7fe1",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Notice of your consent",
+          "defaultHtmlTemplate": "@{emails/coppa-notice.html.ftl}",
+          "defaultTextTemplate": "@{emails/coppa-notice.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "COPPA Notice"
+        }
+      }
+    },
+
+
+    {
+      "method": "POST",
+      "url": "/api/email/template/f0e9d738-c98d-45ee-b869-8636342c5158",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Reminder: Notice of your consent",
+          "defaultHtmlTemplate": "@{emails/coppa-email-plus-notice.html.ftl}",
+          "defaultTextTemplate": "@{emails/coppa-email-plus-notice.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "COPPA Notice Reminder"
+        }
+      }
+    },
+
+
+    {
+      "method": "POST",
+      "url": "/api/email/template/e6c74b53-d43d-471e-ae7e-906456d0f341",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Your password is not secure",
+          "defaultHtmlTemplate": "@{emails/breached-password.html.ftl}",
+          "defaultTextTemplate": "@{emails/breached-password.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "Breached Password Notification"
+        }
+      }
+    },
+
+    {
+      "method": "POST",
+      "url": "/api/email/template/95392509-e501-4efa-a237-5aa2617965f6",
+      "body": {
+        "emailTemplate": {
+          "defaultFromName": "FusionAuth Development",
+          "defaultSubject": "Your second factor code",
+          "defaultHtmlTemplate": "@{emails/2fa.html.ftl}",
+          "defaultTextTemplate": "@{emails/2fa.txt.ftl}",
+          "fromEmail": "dev@fusionauth.io",
+          "name": "Two Factor Authentication"
+        }
+      }
+    },
+    {
+      "method": "PATCH",
+      "url": "/api/tenant/#{defaultTenantId}",
+      "body": {
+        "tenant": {
+          "emailConfiguration": {},
+          "multiFactorConfiguration": {
+            "email": {
+              "templateId": "95392509-e501-4efa-a237-5aa2617965f6"}
+          }
+        }
+      }
     }
+
   ]
 }


### PR DESCRIPTION
d magic link emails are supported in Kickstart for future example documentation.

Email templates taken from: https://github.com/FusionAuth/fusionauth-example-docker-compose/blob/main/kickstart/kickstart/kickstart-development.json with instructions on how to set them for the tenant here: https://fusionauth.io/docs/apis/tenants#request-3